### PR TITLE
Add types for `dump-agent`'s UDP server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humpty"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ static_assertions = { version = "1", default-features = false }
 lzss = { version = "0.8", default-features = false }
 hubpack = { version = "0.1", default-features = false }
 serde = { version = "1.0.114", default-features = false, features = ["derive"] }
+serde-big-array = { version = "0.5" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,6 @@ pub const DUMP_CONTENTS_SINGLETASK: u8 = 1;
 pub const DUMP_CONTENTS_WHOLESYSTEM: u8 = 2;
 pub const DUMP_CONTENTS_INVALID: u8 = 0xff;
 
-/// Contents of a particular dump area
-///
-/// This type is serialized as a network data type; see the explanation in the
-/// `udp` module for how it's allowed to be edited, and remember to run the
-/// test suite.
 #[derive(
     Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]
@@ -139,11 +134,6 @@ impl From<DumpContents> for u8 {
     }
 }
 
-/// Represents a single dump area in the system
-///
-/// This type is serialized as a network data type; see the explanation in the
-/// `udp` module for how it's allowed to be edited, and remember to run the
-/// test suite.
 #[derive(
     Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,11 @@ pub const DUMP_CONTENTS_SINGLETASK: u8 = 1;
 pub const DUMP_CONTENTS_WHOLESYSTEM: u8 = 2;
 pub const DUMP_CONTENTS_INVALID: u8 = 0xff;
 
+/// Contents of a particular dump area
+///
+/// This type is serialized as a network data type; see the explanation in the
+/// `udp` module for how it's allowed to be edited, and remember to run the
+/// test suite.
 #[derive(
     Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]
@@ -129,11 +134,17 @@ impl From<DumpContents> for u8 {
             DumpContents::Available => DUMP_CONTENTS_AVAILABLE,
             DumpContents::SingleTask => DUMP_CONTENTS_SINGLETASK,
             DumpContents::WholeSystem => DUMP_CONTENTS_WHOLESYSTEM,
+            DumpContents::TaskRegion => DUMP_CONTENTS_TASKREGION,
             _ => DUMP_CONTENTS_INVALID,
         }
     }
 }
 
+/// Represents a single dump area in the system
+///
+/// This type is serialized as a network data type; see the explanation in the
+/// `udp` module for how it's allowed to be edited, and remember to run the
+/// test suite.
 #[derive(
     Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@ impl From<DumpContents> for u8 {
             DumpContents::Available => DUMP_CONTENTS_AVAILABLE,
             DumpContents::SingleTask => DUMP_CONTENTS_SINGLETASK,
             DumpContents::WholeSystem => DUMP_CONTENTS_WHOLESYSTEM,
-            DumpContents::TaskRegion => DUMP_CONTENTS_TASKREGION,
             _ => DUMP_CONTENTS_INVALID,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@
 //!  4. Dump is retrieved by Humility for decompressing and processing.
 //!
 
+pub mod udp;
+
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes};

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -20,7 +20,7 @@ pub const DUMP_READ_SIZE: usize = 256;
 )]
 pub struct Header {
     /// The protocol version.
-    version: u8,
+    pub version: u8,
 
     /// An arbitrary message ID, shared between a request and its response.
     pub message_id: u64,

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -72,10 +72,10 @@ pub enum Request {
     /// Initialize dump context, overwriting any taken dump
     InitializeDump,
 
-    /// Add a segment to a dump
+    /// Adds a segment to a whole-system dump
     AddDumpSegment { address: u32, length: u32 },
 
-    /// Take dump
+    /// Take a whole-system dump
     TakeDump,
 }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -76,6 +76,13 @@ pub enum Response {
     Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
 )]
 pub enum Error {
+    // New error type specific to network traffic
+    //
+    // This is deliberately put at the beginning so that new Hubris errors can
+    // be added without changing the encoding order.
+    DeserializeError,
+
+    // Error types from `DumpAgentError`
     DumpAgentUnsupported,
     InvalidArea,
     BadOffset,
@@ -91,6 +98,12 @@ pub enum Error {
     BadSegmentAdd,
     ServerRestarted,
 
-    // New error types specific to network traffic
-    DeserializeError,
+    BadDumpResponse,
+    DumpMessageFailed,
+    DumpFailedSetup,
+    DumpFailedRead,
+    DumpFailedWrite,
+    DumpFailedControl,
+    DumpFailedUnknown,
+    DumpFailedUnknownError,
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -134,7 +134,7 @@ pub enum Error {
     // This are deliberately put at the beginning so that new Hubris errors can
     // be added to the end without changing the encoding order.
     DeserializeError,
-    VersionMismatch,
+    VersionMismatch { ours: u8, theirs: u8 },
 
     // Error types from `DumpAgentError`
     DumpAgentUnsupported,
@@ -194,7 +194,7 @@ mod encoding_tests {
         let mut buf = [0u8; Error::MAX_SIZE];
         const TEST_DATA: [Error; 24] = [
             Error::DeserializeError,
-            Error::VersionMismatch,
+            Error::VersionMismatch { ours: 0, theirs: 0 },
             Error::DumpAgentUnsupported,
             Error::InvalidArea,
             Error::BadOffset,
@@ -231,6 +231,10 @@ mod encoding_tests {
                 avoid reordering or removing variants."
             );
         }
+
+        let r = Error::VersionMismatch { ours: 123, theirs: 251 };
+        let size = hubpack::serialize(&mut buf, &r).unwrap();
+        assert_eq!(buf[..size], [1, 123, 251]);
     }
 
     #[test]

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -89,8 +89,8 @@ pub enum Request {
 )]
 #[allow(clippy::large_enum_variant)]
 pub struct RequestMessage {
-    header: Header,
-    request: Request,
+    pub header: Header,
+    pub request: Request,
 }
 
 /// Responses from the target device to the host
@@ -116,8 +116,8 @@ pub enum Response {
 )]
 #[allow(clippy::large_enum_variant)]
 pub struct ResponseMessage {
-    header: Header,
-    response: Result<Response, Error>,
+    pub header: Header,
+    pub response: Result<Response, Error>,
 }
 
 /// Errors that can be reported by the dump agent

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -72,7 +72,9 @@ pub enum Response {
 ///
 /// This is mostly to `DumpAgentError` in Hubris, but lives in a separate
 /// crate so it can be versioned independently.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, SerializedSize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
+)]
 pub enum Error {
     DumpAgentUnsupported,
     InvalidArea,

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Network messages for remote task dumping
+//!
+//! Messages from the host are serialized as a tuple `(Header, Request)`;
+//! replies from the device are `(Header, Response)`, along with trailing data
+//! in the packet for the actual dump (if relevant).
+
+use crate::DumpArea;
+use hubpack::SerializedSize;
+use serde::{Deserialize, Serialize};
+
+pub const DUMP_READ_SIZE: usize = 256;
+
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
+)]
+pub struct Header {
+    /// The protocol version.
+    version: u8,
+
+    /// An arbitrary message ID, shared between a request and its response.
+    pub message_id: u64,
+}
+
+/// Messages sent from the host to the target device
+///
+/// These are a thin wrapper around the `dump-agent` API in Hubris, but live in
+/// a separate crate so that they can be versioned independently.
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
+)]
+pub enum Request {
+    /// Fetch the 256 bytes from the dump at the specified offset from the
+    /// specified area.
+    ReadDump { index: u8, offset: u32 },
+
+    /// Returns information associated with the specified dump area
+    GetDumpArea { index: u8 },
+
+    /// Initialize dump context, overwriting any taken dump
+    InitializeDump,
+
+    /// Add a segment to a dump
+    AddDumpSegment { address: u32, length: u32 },
+
+    /// Take dump
+    TakeDump,
+}
+
+/// Responses from the target device to the host
+///
+/// Most of these are simple acknowledgements, but some include data (either in
+/// the variant or trailing behind in the packet).
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
+)]
+#[allow(clippy::large_enum_variant)]
+pub enum Response {
+    #[serde(with = "serde_big_array::BigArray")]
+    ReadDump([u8; DUMP_READ_SIZE]),
+    GetDumpArea(DumpArea),
+    InitializeDump,
+    AddDumpSegment,
+    TakeDump,
+}
+
+/// Errors that can be reported by the dump agent
+///
+/// This is mostly to `DumpAgentError` in Hubris, but lives in a separate
+/// crate so it can be versioned independently.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, SerializedSize)]
+pub enum Error {
+    DumpAgentUnsupported,
+    InvalidArea,
+    BadOffset,
+    UnalignedOffset,
+    UnalignedSegmentAddress,
+    UnalignedSegmentLength,
+    DumpFailed,
+    NotSupported,
+    DumpPresent,
+    UnclaimedDumpArea,
+    CannotClaimDumpArea,
+    DumpAreaInUse,
+    BadSegmentAdd,
+    ServerRestarted,
+
+    // New error types specific to network traffic
+    DeserializeError,
+}

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -12,6 +12,7 @@ use crate::DumpArea;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 
+pub const VERSION: u8 = 1;
 pub const DUMP_READ_SIZE: usize = 256;
 
 #[derive(

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -12,7 +12,39 @@ use crate::DumpArea;
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
 
-pub const VERSION: u8 = 1;
+pub mod version {
+    pub const V1: u8 = 1;
+
+    /// The current version of the messaging protocol.
+    pub const CURRENT: u8 = V1;
+
+    /// The minimum supported version that is compatible with the current.
+    ///
+    /// "Compatible" means that all messages from this version may be serialized
+    /// and deserialized correctly. That means that all message data in `MIN`
+    /// correspond to the same values in `CURRENT` -- colloquially, `CURRENT` is
+    /// a superset of `MIN`.
+    ///
+    /// Because this crate uses `hubpack` for serialization, this also means
+    /// that no variants of the message enums have been removed or reordered. So
+    /// `CURRENT` may contain _new_ items, but existing ones cannot be moved or
+    /// removed.
+    ///
+    /// This version of the protocol is _committed_. Any changes to the types
+    /// here, or [`Error`], _must_ be compatible with this version. They can
+    /// add new enum variants, but _must not_ change or reorder any of the
+    /// existing variants. Peers should, on a best-effort basis, decode and
+    /// handle any messages that are at least this version. If the message comes
+    /// from a version prior to their `CURRENT`, they _must_ be able to decode
+    /// it, assuming we've not broken compatibility. If the message comes from a
+    /// version _after_ `CURRENT`, they _may_ be able to decode it. If they
+    /// cannot, presumably because the message was added in a later version,
+    /// then they _must_ still send back a protocol error of some kind, such as
+    /// `Error::VersionMismatch`. Those are guaranteed to be compatible and
+    /// decodable by the peer.
+    pub const MIN: u8 = V1;
+}
+
 pub const DUMP_READ_SIZE: usize = 256;
 
 #[derive(
@@ -70,17 +102,19 @@ pub enum Response {
 
 /// Errors that can be reported by the dump agent
 ///
-/// This is mostly to `DumpAgentError` in Hubris, but lives in a separate
-/// crate so it can be versioned independently.
+/// This is mostly identical to `DumpAgentError` in Hubris, but lives in a
+/// separate crate so it can be versioned independently.  It also includes new
+/// error types specific to networked messages.
 #[derive(
     Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize,
 )]
 pub enum Error {
-    // New error type specific to network traffic
+    // Error types specific to network traffic
     //
-    // This is deliberately put at the beginning so that new Hubris errors can
-    // be added without changing the encoding order.
+    // This are deliberately put at the beginning so that new Hubris errors can
+    // be added to the end without changing the encoding order.
     DeserializeError,
+    VersionMismatch,
 
     // Error types from `DumpAgentError`
     DumpAgentUnsupported,
@@ -106,4 +140,151 @@ pub enum Error {
     DumpFailedControl,
     DumpFailedUnknown,
     DumpFailedUnknownError,
+}
+
+#[cfg(test)]
+mod encoding_tests {
+    use super::{Error, Request, Response, DUMP_READ_SIZE};
+    use crate::{DumpArea, DumpContents};
+    use core::convert::TryFrom;
+    use hubpack::SerializedSize;
+
+    // Tests that the current version has not broken serialization.
+    //
+    // This uses the fact that `hubpack` assigns IDs to each variant of an enum
+    // based on the order they appear.  These are used by
+    // `hubpack::{serialize,deserialize}` to determine the enum variant encoded
+    // in a binary message, which are based on the _ordering_ of the enum
+    // variants. I.e, we're really testing if that ordering has changed in a
+    // meaningful way.
+    //
+    // If it _has_, we have two options:
+    //
+    // - Bump `MIN` -> `CURRENT`
+    // - Rework the changes to avoid that change.
+    //
+    // Each test below checks one of the enums in the protocol.
+
+    // Test that the error variant encoding has not changed.
+    #[test]
+    fn test_error_encoding_unchanged() {
+        let mut buf = [0u8; Error::MAX_SIZE];
+        const TEST_DATA: [Error; 24] = [
+            Error::DeserializeError,
+            Error::VersionMismatch,
+            Error::DumpAgentUnsupported,
+            Error::InvalidArea,
+            Error::BadOffset,
+            Error::UnalignedOffset,
+            Error::UnalignedSegmentAddress,
+            Error::UnalignedSegmentLength,
+            Error::DumpFailed,
+            Error::NotSupported,
+            Error::DumpPresent,
+            Error::UnclaimedDumpArea,
+            Error::CannotClaimDumpArea,
+            Error::DumpAreaInUse,
+            Error::BadSegmentAdd,
+            Error::ServerRestarted,
+            Error::BadDumpResponse,
+            Error::DumpMessageFailed,
+            Error::DumpFailedSetup,
+            Error::DumpFailedRead,
+            Error::DumpFailedWrite,
+            Error::DumpFailedControl,
+            Error::DumpFailedUnknown,
+            Error::DumpFailedUnknownError,
+        ];
+
+        for (variant_id, variant) in TEST_DATA.iter().enumerate() {
+            buf[0] = u8::try_from(variant_id).unwrap();
+            let (decoded, _rest) =
+                hubpack::deserialize::<Error>(buf.as_slice()).unwrap();
+            assert_eq!(
+                variant, &decoded,
+                "Serialization encoding changed! Either `version::CURRENT` \
+                or `version::MIN` will need to be updated, \
+                or the changes to `crate::udp::Error` need to be reworked to \
+                avoid reordering or removing variants."
+            );
+        }
+    }
+
+    #[test]
+    fn test_request_encoding_unchanged() {
+        let mut buf = [0u8; Request::MAX_SIZE];
+        const TEST_DATA: [Request; 5] = [
+            Request::ReadDump { index: 0, offset: 0 },
+            Request::GetDumpArea { index: 0 },
+            Request::InitializeDump,
+            Request::AddDumpSegment { address: 0, length: 0 },
+            Request::TakeDump,
+        ];
+
+        for (variant_id, variant) in TEST_DATA.iter().enumerate() {
+            buf[0] = u8::try_from(variant_id).unwrap();
+            let (decoded, _rest) =
+                hubpack::deserialize::<Request>(buf.as_slice()).unwrap();
+            assert_eq!(
+                variant, &decoded,
+                "Serialization encoding changed! Either `version::CURRENT` \
+                or `version::MIN` will need to be updated, \
+                or the changes to `crate::udp::Request` need to be reworked to \
+                avoid reordering or removing variants."
+            );
+        }
+    }
+
+    #[test]
+    fn test_response_encoding_unchanged() {
+        let mut buf = [0u8; Response::MAX_SIZE];
+        const TEST_DATA: [Response; 5] = [
+            Response::ReadDump([0u8; DUMP_READ_SIZE]),
+            Response::GetDumpArea(DumpArea {
+                address: 0,
+                contents: DumpContents::Available,
+                length: 0,
+            }),
+            Response::InitializeDump,
+            Response::AddDumpSegment,
+            Response::TakeDump,
+        ];
+
+        for (variant_id, variant) in TEST_DATA.iter().enumerate() {
+            buf[0] = u8::try_from(variant_id).unwrap();
+            let (decoded, _rest) =
+                hubpack::deserialize::<Response>(buf.as_slice()).unwrap();
+            assert_eq!(
+                variant, &decoded,
+                "Serialization encoding changed! Either `version::CURRENT` \
+                or `version::MIN` will need to be updated, \
+                or the changes to `crate::udp::Response` need to be reworked \
+                to avoid reordering or removing variants."
+            );
+        }
+    }
+
+    #[test]
+    fn test_dumpcontents_encoding_unchanged() {
+        let mut buf = [0u8; DumpContents::MAX_SIZE];
+        const TEST_DATA: [DumpContents; 4] = [
+            DumpContents::Available,
+            DumpContents::SingleTask,
+            DumpContents::WholeSystem,
+            DumpContents::Unknown,
+        ];
+
+        for (variant_id, variant) in TEST_DATA.iter().enumerate() {
+            buf[0] = u8::try_from(variant_id).unwrap();
+            let (decoded, _rest) =
+                hubpack::deserialize::<DumpContents>(buf.as_slice()).unwrap();
+            assert_eq!(
+                variant, &decoded,
+                "Serialization encoding changed! Either `version::CURRENT` \
+                or `version::MIN` will need to be updated, \
+                or the changes to `crate::DumpContents` need to be reworked to \
+                avoid reordering or removing variants."
+            );
+        }
+    }
 }


### PR DESCRIPTION
As part of https://github.com/oxidecomputer/hubris/issues/1217, we want `dump-agent` to speak UDP directly, instead of going through `task-udprpc` and hiffy.

This means that Hubris and Humility must have a common type of network message that each side knows how to serialize and deserialize.

This PR implements such types for networked communication.  It's based on https://github.com/oxidecomputer/management-gateway-service/pull/68 for the versioning scheme, where we have a `MIN` (minimum supported version) and `CURRENT`; new types may be added without changing `MIN`, but they must be strictly additive.

(Ideally, we'll keep `MIN` at `1` forever)