### PR TITLE
Add new types for remote dumping of tasks (full and partial)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humpty"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,9 @@ impl From<DumpContents> for u8 {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
+)]
 pub struct DumpAreaRegion {
     /// Base address of this dump area
     pub address: u32,
@@ -148,7 +150,9 @@ pub struct DumpAreaRegion {
     pub length: u32,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    Copy, Clone, Debug, SerializedSize, Serialize, Deserialize, PartialEq, Eq,
+)]
 pub struct DumpArea {
     /// Memory range covered by this dump area
     pub region: DumpAreaRegion,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,19 +614,15 @@ pub fn claim_dump_area<T>(
 
 ///
 /// Called by the dump agent proxy to release dump areas starting at the given
-/// index.
+/// address, which must point to a valid `DumpAreaHeader`.
 ///
 /// All dump areas at and after the given index are reinitialized.
 ///
 pub fn release_dump_areas_from<T>(
-    base: u32,
-    index: u8,
+    mut address: u32,
     mut read: impl FnMut(u32, &mut [u8], bool) -> Result<(), T>,
     mut write: impl FnMut(u32, &[u8]) -> Result<(), T>,
 ) -> Result<(), DumpError<T>> {
-    let area = get_dump_area(base, index, &mut read)?;
-
-    let mut address = area.address;
     while address != 0 {
         let mut header = DumpAreaHeader::read_and_check(address, &mut read)?;
 


### PR DESCRIPTION
This PR adds three new APIs to the UDP interface:

- Dump a single task (by task index)
- Dump a subregion of a single task (by task index + address + length)
- Reinitialize dump memory starting at a particular area index

In addition, it adds a few things to `humpty` proper:

- `DUMP_CONTENTS_TASKREGION` is a new contents marker for a task subregion dump
- `dump_address_to_index` converts from an address (`u32`) to an area index
- `release_dump_areas_from` reinitializes dump memory starting at a particular address (used to implement the last operation above)

I'm not totally sold on `dump_address_to_index`.  It's necessary because `claim_dump_area` returns a `DumpArea` (with an address but not an index), but many other functions expect a dump area `index`.  One option would be to add an `index: u8` to the `struct DumpArea`.  However, that's _also_ awkward because `DumpArea` is used for configuration, e.g.

```rust
pub(crate) const DUMP_AREAS: [humpty::DumpArea; 3] = [
    // sram2 dump area
    humpty::DumpArea {
        address: 0x30020000,
        length: 0x20000,
        contents: humpty::DumpContents::Available,
    },

    // sram3 dump area
    humpty::DumpArea {
        address: 0x30040000,
        length: 0x8000,
        contents: humpty::DumpContents::Available,
    },

    // sram4 dump area
    humpty::DumpArea {
        address: 0x38000000,
        length: 0x10000,
        contents: humpty::DumpContents::Available,
    },
];
```

Having an index would be helpful when a `DumpArea` is returned, but not useful when a `DumpArea` is used as a configuration value; perhaps we could introduce a new `DumpAreaRange` type used for configuration, which also lacks the `contents` field?