### PR TITLE
add GetImageId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "humpty"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Draft comment:

```
This adds support for GetImageId (which is necessary to address
humility#395 and bumps the version of the UDP protocol to 3.
```
