### PR TITLE
Update to `zerocopy` v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.4"
 edition = "2018"
 
 [dependencies]
-zerocopy = "0.6.1"
+zerocopy = { version = "0.8.25", features = ["derive"] }
 static_assertions = { version = "1", default-features = false }
 lzss = { version = "0.8", default-features = false }
 hubpack = { version = "0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.4"
 edition = "2018"
 
 [dependencies]
-zerocopy = { version = "0.8.25", features = ["derive"] }
+zerocopy = "0.8.25"
+zerocopy-derive = "0.8.25"
 static_assertions = { version = "1", default-features = false }
 lzss = { version = "0.8", default-features = false }
 hubpack = { version = "0.1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ pub mod udp;
 
 use hubpack::SerializedSize;
 use serde::{Deserialize, Serialize};
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, IntoBytes};
+use zerocopy_derive::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const DUMP_MAGIC: [u8; 4] = [0x1, 0xde, 0xde, 0xad];
 pub const DUMP_UNINITIALIZED: [u8; 4] = [0xba, 0xd, 0xca, 0xfe];
@@ -83,7 +84,7 @@ pub const DUMPER_EXTERNAL: u8 = 1;
 pub const DUMPER_JEFE: u8 = 2;
 
 //
-// Constants for dump contents.  Other than [`DUMP_CONTENTS_AVAILABLE`] being
+// Constants for dump contents.  Other than [`DUMP_CONTENTS_AVAILABLE`] being'd
 // denoted with zero, the specific values should not be assumed to have
 // meaning across domains.  That is, these contents constants can be used to
 // assert invariants *within* a single domain, but should *not* be used to


### PR DESCRIPTION
This commit updates `humpty` from `zerocopy` v0.6 to v0.8. This is mostly a fairly mechanical translation. I think we could, potentially, change how the `DumpSegment` enum works by instead using `zerocopy` 0.8's new support for enums with data so that the magic numbers become enum discriminants and the entire enum can be zero-copy `TryFromBytes`-ed, but that's a somewhat more complex change, and I wanted to get this working first.