### PR TITLE
Update dependencies; safety tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "humpty"
-version = "0.1.4"
-edition = "2018"
+version = "0.1.5"
+edition = "2024"
 
 [dependencies]
-zerocopy = "0.8.25"
-zerocopy-derive = "0.8.25"
+zerocopy = "0.8.48"
+zerocopy-derive = "0.8.48"
 static_assertions = { version = "1", default-features = false }
-lzss = { version = "0.8", default-features = false }
+lzss = { version = "0.9", default-features = false }
 hubpack = { version = "0.1", default-features = false }
-serde = { version = "1.0.114", default-features = false, features = ["derive"] }
+serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 serde-big-array = { version = "0.5" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.65.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,7 @@ pub enum DumpError<T> {
 //
 pub type DumpLzss = lzss::Lzss<6, 4, 0x20, { 1 << 6 }, { 2 << 6 }>;
 
+///
 /// A convenience routine to offer as the `read` parameter to routines that
 /// operate on a dump area when that dump area is backed by memory (i.e.,
 /// within the same domain).  This should *only* be used as a parameter to
@@ -393,10 +394,12 @@ pub type DumpLzss = lzss::Lzss<6, 4, 0x20, { 1 << 6 }, { 2 << 6 }>;
 ///
 /// # Safety
 ///
-/// Should only be used as a parameter to Humpty routines that take a
-/// closure to read from a dump area, and only then when the dump area is
-/// backed by a memory that can be operated upon as a memory (i.e., with
-/// the same allowances with respect to address alignment).
+/// Should only be used as a parameter to Humpty routines that take a closure to
+/// read from a dump area, and only then when the dump area is backed by a
+/// memory that can be operated upon as a memory (i.e., with the same allowances
+/// with respect to address alignment).  The memory range of `addr..addr +
+/// buf.len()` must not overlap with `buf` itself.
+///
 #[allow(clippy::result_unit_err)]
 pub unsafe fn from_mem(addr: u32, buf: &mut [u8]) -> Result<(), ()> {
     let src = addr as *mut u8;
@@ -406,6 +409,7 @@ pub unsafe fn from_mem(addr: u32, buf: &mut [u8]) -> Result<(), ()> {
     Ok(())
 }
 
+///
 /// A convenience routine to offer as the `write` parameter to routines that
 /// operate on a dump area when that dump area is backed by memory (i.e.,
 /// within the same domain).  As with [`from_mem`], this should *only* be used
@@ -414,10 +418,12 @@ pub unsafe fn from_mem(addr: u32, buf: &mut [u8]) -> Result<(), ()> {
 ///
 /// # Safety
 ///
-/// Should only be used as a parameter to Humpty routines that take a
-/// closure to write to a dump area, and only then when the dump area is
-/// backed by a memory that can be operated upon as a memory (i.e., with
-/// the same allowances with respect to address alignment).
+/// Should only be used as a parameter to Humpty routines that take a closure to
+/// write to a dump area, and only then when the dump area is backed by a memory
+/// that can be operated upon as a memory (i.e., with the same allowances with
+/// respect to address alignment).  The memory range of `addr..addr + buf.len()`
+/// must not overlap with `buf` itself.
+///
 #[allow(clippy::result_unit_err)]
 pub unsafe fn to_mem(addr: u32, buf: &[u8]) -> Result<(), ()> {
     let dest = addr as *mut u8;
@@ -427,7 +433,6 @@ pub unsafe fn to_mem(addr: u32, buf: &[u8]) -> Result<(), ()> {
     Ok(())
 }
 
-///
 /// Initialize the dump areas based on the specified list.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,6 @@ pub enum DumpError<T> {
 //
 pub type DumpLzss = lzss::Lzss<6, 4, 0x20, { 1 << 6 }, { 2 << 6 }>;
 
-///
 /// A convenience routine to offer as the `read` parameter to routines that
 /// operate on a dump area when that dump area is backed by memory (i.e.,
 /// within the same domain).  This should *only* be used as a parameter to
@@ -398,15 +397,15 @@ pub type DumpLzss = lzss::Lzss<6, 4, 0x20, { 1 << 6 }, { 2 << 6 }>;
 /// closure to read from a dump area, and only then when the dump area is
 /// backed by a memory that can be operated upon as a memory (i.e., with
 /// the same allowances with respect to address alignment).
-///
 #[allow(clippy::result_unit_err)]
 pub unsafe fn from_mem(addr: u32, buf: &mut [u8]) -> Result<(), ()> {
-    let src = core::slice::from_raw_parts(addr as *const u8, buf.len());
-    buf.copy_from_slice(src);
+    let src = addr as *mut u8;
+    // SAFETY: the caller asserts that addr is a valid pointer to a region of at
+    // least `buf.len()` bytes
+    unsafe { src.copy_to_nonoverlapping(buf.as_mut_ptr(), buf.len()) }
     Ok(())
 }
 
-///
 /// A convenience routine to offer as the `write` parameter to routines that
 /// operate on a dump area when that dump area is backed by memory (i.e.,
 /// within the same domain).  As with [`from_mem`], this should *only* be used
@@ -419,18 +418,22 @@ pub unsafe fn from_mem(addr: u32, buf: &mut [u8]) -> Result<(), ()> {
 /// closure to write to a dump area, and only then when the dump area is
 /// backed by a memory that can be operated upon as a memory (i.e., with
 /// the same allowances with respect to address alignment).
-///
 #[allow(clippy::result_unit_err)]
 pub unsafe fn to_mem(addr: u32, buf: &[u8]) -> Result<(), ()> {
-    let dest = core::slice::from_raw_parts_mut(addr as *mut u8, buf.len());
-    dest.copy_from_slice(buf);
+    let dest = addr as *mut u8;
+    // SAFETY: the caller asserts that addr is a valid pointer to a region of at
+    // least `buf.len()` bytes
+    unsafe { dest.copy_from_nonoverlapping(buf.as_ptr(), buf.len()) }
     Ok(())
 }
 
 ///
 /// Initialize the dump areas based on the specified list.
 ///
-pub fn initialize_dump_areas(
+/// # Safety
+/// `areas` must refer to valid writeable memory (i.e. exclusively owned when
+/// this function is called).
+pub unsafe fn initialize_dump_areas(
     areas: &[DumpAreaRegion],
     chunksize: Option<usize>,
 ) -> Option<u32> {


### PR DESCRIPTION
- Updates to Rust 2024
- Removed `rust-toolchain.toml` (doesn't make sense for library crates)
- Bump deps (some `zerocopy` trait churn)
- Tweak safety properties
  - `to_mem` and `from_mem` no longer construct a slice, because they could be passed uninitialized memory
  - `initialize_dump_areas` is now `unsafe`, because it writes to arbitrary caller-provided memory
